### PR TITLE
Catsup文档介绍不全

### DIFF
--- a/docs/start.rst
+++ b/docs/start.rst
@@ -113,7 +113,6 @@ Catsup 可以被很自由的定制，但你只要改几个设置就可以让你�
 
 你需要一个叫做 `YOUR_GITHUB_USERNAME.github.io` 的 repo 。 如果你还没有，现在去 `创建一个 <https://github.com/repositories/new>`_ 吧。
 
-
 然后修改你的配置文件， 将 ``deploy`` 部分改成这样 ::
 
     "deploy": {
@@ -127,6 +126,16 @@ Catsup 可以被很自由的定制，但你只要改几个设置就可以让你�
     },
 
 用你的 GitHub 用户名（ 比如 ``whtsky`` ） 替换掉 ``YOUR_GITHUB_USERNAME`` 。
+
+然后，进入到刚刚生成站点步骤里面生成的deploy文件夹，添加 ``YOUR_GITHUB_USERNAME.github.io`` 项目的git本地仓库 ::
+
+    cd deploy
+    git init
+    git remote add origin git@github.com:YOUR_GITHUB_USERNAME/YOUR_GITHUB_USERNAME.github.io.git
+
+在切换回主目录 ::
+
+    cd ..
 
 在这之后，让我们把站点部署到 GitHub Pages 上 ::
 


### PR DESCRIPTION
我今天使用catsup，按照中文官方文档，某一步出现些问题

使用catsup build && catsup deploy的目的是把站点生成的html文件push到YOUR_GITHUB_USERNAME.github.io的远程仓库，文档忽略要在deploy目录（而且必须是deploy目录）添加git 本地仓库（即git init）

具体看一下我pull request的文件修改

若我所述有误，就把关闭我的PR
